### PR TITLE
Allow heading and link text customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
-# single row post
+# Single Row Post
 
-Get the latest post on a page. Using a shortcode.
+Get the latest post on a page using a shortcode.
 
-simple add the shortcode [singlerowpost] and get the first blog post
+## Usage
 
+Add the shortcode in the content editor.
 
-The first Half of the row is the the featured image
+```php
+[single_row_post heading="Latest Blog Post" link_text="Read More"]
+```
 
-The other side is the word LATEST NEWS, title, dates, an except of the content (either at 50 words or specified amount), and a link to the actual blog post(the link doesnt work yet)
+The image displayed to the left of the excerpt is the post's featured image.

--- a/bin/new_release
+++ b/bin/new_release
@@ -1,0 +1,96 @@
+#!/bin/bash
+
+# Tags the library with the version number listed in the composer.json file, and
+# pushes the tag to GitHub.
+
+set -e
+
+release_branch="master"
+root="$(git rev-parse --show-toplevel)"
+
+tag() {
+  jq -r ".version" "$(root)/composer.json"
+}
+
+current_branch() {
+  git symbolic-ref --short -q HEAD
+}
+
+on_release_branch() {
+  if [ ! "$(current_branch)" == "$release_branch" ]; then
+    return 1
+  fi
+}
+
+ensure_on_release_branch() {
+  if ! on_release_branch; then
+    local msg="This script can only run from the release branch.\n\n"
+    msg+="release branch: $release_branch\n"
+    msg+="current branch: $(current_branch)"
+
+    echo -e "$msg"
+    exit 1
+  fi
+}
+
+local_sha() {
+  git rev-parse "$(current_branch)"
+}
+
+remote_sha() {
+  git rev-parse "origin/$(current_branch)"
+}
+
+up_to_date() {
+  git fetch --all --quiet
+
+  if [ ! "$(local_sha)" == "$(remote_sha)" ]; then
+    return 1
+  fi
+}
+
+clean_working_dir() {
+  if [ ! -z "$(git status --porcelain)" ]; then
+    return 1
+  fi
+}
+
+check_if_up_to_date() {
+  if ! up_to_date || ! clean_working_dir; then
+    echo -e "Current branch is out of date - push/pull before retrying."
+    exit 1
+  fi
+}
+
+tag_already_exists() {
+  git show-ref --tags --quiet --verify -- "refs/tags/$(tag)"
+}
+
+check_if_tag_exists() {
+  if tag_already_exists; then
+    echo -e "A tag already exists for version $(tag)."
+    exit 1
+  fi
+}
+
+regenerate_autoloader() {
+  composer dump-autoload -a -q
+
+  if ! clean_working_dir; then
+    git add -A
+    git commit -m "Regenerate the autoloader"
+    git push origin "$release_branch" > /dev/null 2>&1
+  fi
+}
+
+create_release() {
+  git tag -a "$(tag)" -m "$(tag)"
+  git push origin "$release_branch" --tags > /dev/null 2>&1
+}
+
+ensure_on_release_branch
+check_if_tag_exists
+check_if_up_to_date
+regenerate_autoloader
+check_if_up_to_date
+create_release && echo "Released v$(tag)."

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "xzito/single_row_post",
-    "version": "0.1.0",
+    "version": "0.2.0",
     "description": "Get the latest post on a page. Using a shortcode.",
     "type": "wordpress-plugin",
     "authors": [{

--- a/css/style.css
+++ b/css/style.css
@@ -1,4 +1,4 @@
-.singlerowpost-latest-news {
+.singlerowpost-heading {
     text-transform: uppercase;
 }
 

--- a/single_row_post.php
+++ b/single_row_post.php
@@ -1,12 +1,12 @@
 <?php
 
 /**
-* Plugin Name: Single Row Post
-* Description: Get the latest post on a page. Using a shortcode.
-* Version: 0.1
-* Author: Nick Mole
-* Text Domain: srp-single-row-post
-*/
+ * Plugin Name: Single Row Post
+ * Description: Get the latest post on a page. Using a shortcode.
+ * Version: 0.2.0
+ * Author: Nick Mole
+ * Text Domain: srp-single-row-post
+ */
 
 require_once plugin_dir_path(__FILE__) . 'src/SingleRowPost.php';
 require_once plugin_dir_path(__FILE__) . 'src/Helpers.php';
@@ -18,6 +18,10 @@ use Mole\SRP\Helpers;
 new SingleRowPost();
 
 add_action('wp_footer', function() {
-  wp_register_style('singleRowPost', plugins_url('single_row_post/css/'). 'style.css');
-  wp_enqueue_style('singleRowPost' );
+  wp_register_style(
+    'singleRowPost',
+    plugins_url('single_row_post/css/') . 'style.css'
+  );
+
+  wp_enqueue_style('singleRowPost');
 });

--- a/src/SingleRowPost.php
+++ b/src/SingleRowPost.php
@@ -5,19 +5,33 @@ namespace Mole\SRP;
 use Mole\SRP\Helpers;
 
 class SingleRowPost {
+  private const DEFAULT_ATTS = [
+    'heading' => "What's New",
+    'link_text' => 'Read Full Story',
+  ];
 
   public function __construct() {
-    add_shortcode('singlerowpost', [$this, 'render_first_blog_post']);
+    add_shortcode('single_row_post', [$this, 'render_first_blog_post'], 10, 1);
   }
 
-  public function render_first_blog_post() {
+  public function render_first_blog_post($atts, $content) {
+    $atts = $this->atts_with_defaults($atts);
+    $heading = $atts['heading'];
+    $link_text = $atts['link_text'];
     $posts = get_posts(['numberposts' => 1, 'post_type' => 'post']);
 
     foreach ($posts as $post) {
       setup_postdata($post);
-      include Helpers::get_template_path('featured_blog_post.php');
+
+      require Helpers::get_template_path('featured_blog_post.php');
     }
 
     wp_reset_postdata();
+  }
+
+  private function atts_with_defaults($atts) {
+    $atts_array = ($atts == '' ? [] : $atts);
+
+    return array_merge(self::DEFAULT_ATTS, $atts_array);
   }
 }

--- a/templates/featured_blog_post.php
+++ b/templates/featured_blog_post.php
@@ -15,12 +15,12 @@ $title        = get_the_title($post->ID);
   </div>
   <div class="col-md-6">
     <div class="contain-singlerowpost-content">
-      <h4 class="singlerowpost-latest-news">News</h4>
+      <h4 class="singlerowpost-heading"><?= $heading ?></h4>
       <h4 class="archive-title singlerowpost-title"><?= $title ?></h4>
       <div class="archive-time-line singlerowpost-time"><?= $published_at ?></div>
       <p><?= $excerpt ?></p>
       <div class="singlerowpost-title singlerowpost-link">
-        <a href="<?= $link ?>">Read Full Story</a>
+        <a href="<?= $link ?>"><?= $link_text ?></a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Parameterize the `single_row_post` shortcut so that the heading and link
text can be specified from the content editor.